### PR TITLE
fix(core): check for existing context in `BaseTextComponent.text`

### DIFF
--- a/packages/src/view/base.ts
+++ b/packages/src/view/base.ts
@@ -162,7 +162,7 @@ export class BaseTextComponent extends BaseComponent<SlateTextContext> implement
     initialized = false;
 
     get text(): Text {
-        return this._context.text;
+        return this._context && this._context.text;
     }
 
     ngOnInit() {


### PR DESCRIPTION
Without this the destructor fails with an error that breaks the application. This is also consistent with the rest of the code where the context is always being checked