### PR TITLE
fix(core): turn all dependencies to be peer, target the issue #142

### DIFF
--- a/packages/package.json
+++ b/packages/package.json
@@ -1,14 +1,12 @@
 {
     "name": "slate-angular",
     "version": "1.7.0",
-    "dependencies": {
+    "peerDependencies": {
+        "slate": ">= 0.63.0",
         "tslib": "^2.0.0",
         "slate-history": "^0.62.0",
         "debug": "^4.1.1",
         "direction": "^1.0.3",
         "is-hotkey": "^0.1.6"
-    },
-    "peerDependencies": {
-        "slate": ">= 0.63.0"
     }
 }


### PR DESCRIPTION
Currently the README declares that the consumer should install the dependencies manually, however the same (but not the same actually, see below) libs are claimed to be dependencies.

In fact, both dependencies are being installed. Webpack ignores the dependencies from this package.json anyway, however npm still shows it in audits etc.

The correct approach would be to let users decide on particular versions of the libraries this package depends on => all should be peer.