### PR TITLE
chore(core): correct value type for paste event

### DIFF
--- a/packages/src/components/editable/editable.component.ts
+++ b/packages/src/components/editable/editable.component.ts
@@ -131,7 +131,7 @@ export class SlateEditableComponent implements OnInit, OnChanges, OnDestroy, Aft
     @Input() drop: (event: DragEvent) => void;
     @Input() focus: (event: Event) => void;
     @Input() keydown: (event: KeyboardEvent) => void;
-    @Input() paste: (event: KeyboardEvent) => void;
+    @Input() paste: (event: ClipboardEvent) => void;
     //#endregion
 
     //#region DOM attr


### PR DESCRIPTION
Incorrect type for paste event in editable component. Can't get clipboardData in template strict mode. : )