### PR TITLE
remove debug from dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,6 @@ Chrome、Edge、Safari、Firefox、QQ Browser
 
 ```
 "dependencies": {
-    "debug": "^4.1.1",
     "direction": "^1.0.3",
     "is-hotkey": "^0.1.6",
     "slate": "0.67.1",

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -46,7 +46,6 @@ Chrome、Edge、Safari、Firefox、QQ Browser
 
 ```
 "dependencies": {
-    "debug": "^4.1.1",
     "direction": "^1.0.3",
     "is-hotkey": "^0.1.6",
     "slate": "0.67.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,7 +5,7 @@
   "packages": {
     "packages": {
       "name": "slate-angular",
-      "version": "13.0.2",
+      "version": "14.1.2",
       "license": "MIT",
       "peerDependencies": {
         "debug": "^4.1.1",
@@ -30,7 +30,6 @@
         "@angular/platform-browser": "~14.1.2",
         "@angular/platform-browser-dynamic": "~14.1.2",
         "@angular/router": "^14.1.2",
-        "debug": "^4.1.1",
         "direction": "^1.0.3",
         "is-hotkey": "^0.1.6",
         "rxjs": "~6.6.0",
@@ -8813,14 +8812,6 @@
         "esbuild-windows-arm64": "0.14.49"
       }
     },
-    "node_modules/esbuild-android-64": {
-      "dev": true,
-      "optional": true
-    },
-    "node_modules/esbuild-android-arm64": {
-      "dev": true,
-      "optional": true
-    },
     "node_modules/esbuild-darwin-64": {
       "version": "0.14.49",
       "cpu": [
@@ -8836,62 +8827,6 @@
         "node": ">=12"
       }
     },
-    "node_modules/esbuild-darwin-arm64": {
-      "dev": true,
-      "optional": true
-    },
-    "node_modules/esbuild-freebsd-64": {
-      "dev": true,
-      "optional": true
-    },
-    "node_modules/esbuild-freebsd-arm64": {
-      "dev": true,
-      "optional": true
-    },
-    "node_modules/esbuild-linux-32": {
-      "dev": true,
-      "optional": true
-    },
-    "node_modules/esbuild-linux-64": {
-      "dev": true,
-      "optional": true
-    },
-    "node_modules/esbuild-linux-arm": {
-      "dev": true,
-      "optional": true
-    },
-    "node_modules/esbuild-linux-arm64": {
-      "dev": true,
-      "optional": true
-    },
-    "node_modules/esbuild-linux-mips64le": {
-      "dev": true,
-      "optional": true
-    },
-    "node_modules/esbuild-linux-ppc64le": {
-      "dev": true,
-      "optional": true
-    },
-    "node_modules/esbuild-linux-riscv64": {
-      "dev": true,
-      "optional": true
-    },
-    "node_modules/esbuild-linux-s390x": {
-      "dev": true,
-      "optional": true
-    },
-    "node_modules/esbuild-netbsd-64": {
-      "dev": true,
-      "optional": true
-    },
-    "node_modules/esbuild-openbsd-64": {
-      "dev": true,
-      "optional": true
-    },
-    "node_modules/esbuild-sunos-64": {
-      "dev": true,
-      "optional": true
-    },
     "node_modules/esbuild-wasm": {
       "version": "0.14.49",
       "dev": true,
@@ -8903,17 +8838,309 @@
         "node": ">=12"
       }
     },
-    "node_modules/esbuild-windows-32": {
+    "node_modules/esbuild/node_modules/esbuild-android-64": {
+      "version": "0.14.49",
+      "resolved": "https://registry.npmjs.org/esbuild-android-64/-/esbuild-android-64-0.14.49.tgz",
+      "integrity": "sha512-vYsdOTD+yi+kquhBiFWl3tyxnj2qZJsl4tAqwhT90ktUdnyTizgle7TjNx6Ar1bN7wcwWqZ9QInfdk2WVagSww==",
+      "cpu": [
+        "x64"
+      ],
       "dev": true,
-      "optional": true
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
     },
-    "node_modules/esbuild-windows-64": {
+    "node_modules/esbuild/node_modules/esbuild-android-arm64": {
+      "version": "0.14.49",
+      "resolved": "https://registry.npmjs.org/esbuild-android-arm64/-/esbuild-android-arm64-0.14.49.tgz",
+      "integrity": "sha512-g2HGr/hjOXCgSsvQZ1nK4nW/ei8JUx04Li74qub9qWrStlysaVmadRyTVuW32FGIpLQyc5sUjjZopj49eGGM2g==",
+      "cpu": [
+        "arm64"
+      ],
       "dev": true,
-      "optional": true
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
     },
-    "node_modules/esbuild-windows-arm64": {
+    "node_modules/esbuild/node_modules/esbuild-darwin-arm64": {
+      "version": "0.14.49",
+      "resolved": "https://registry.npmjs.org/esbuild-darwin-arm64/-/esbuild-darwin-arm64-0.14.49.tgz",
+      "integrity": "sha512-XMaqDxO846srnGlUSJnwbijV29MTKUATmOLyQSfswbK/2X5Uv28M9tTLUJcKKxzoo9lnkYPsx2o8EJcTYwCs/A==",
+      "cpu": [
+        "arm64"
+      ],
       "dev": true,
-      "optional": true
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/esbuild/node_modules/esbuild-freebsd-64": {
+      "version": "0.14.49",
+      "resolved": "https://registry.npmjs.org/esbuild-freebsd-64/-/esbuild-freebsd-64-0.14.49.tgz",
+      "integrity": "sha512-NJ5Q6AjV879mOHFri+5lZLTp5XsO2hQ+KSJYLbfY9DgCu8s6/Zl2prWXVANYTeCDLlrIlNNYw8y34xqyLDKOmQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/esbuild/node_modules/esbuild-freebsd-arm64": {
+      "version": "0.14.49",
+      "resolved": "https://registry.npmjs.org/esbuild-freebsd-arm64/-/esbuild-freebsd-arm64-0.14.49.tgz",
+      "integrity": "sha512-lFLtgXnAc3eXYqj5koPlBZvEbBSOSUbWO3gyY/0+4lBdRqELyz4bAuamHvmvHW5swJYL7kngzIZw6kdu25KGOA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/esbuild/node_modules/esbuild-linux-32": {
+      "version": "0.14.49",
+      "resolved": "https://registry.npmjs.org/esbuild-linux-32/-/esbuild-linux-32-0.14.49.tgz",
+      "integrity": "sha512-zTTH4gr2Kb8u4QcOpTDVn7Z8q7QEIvFl/+vHrI3cF6XOJS7iEI1FWslTo3uofB2+mn6sIJEQD9PrNZKoAAMDiA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/esbuild/node_modules/esbuild-linux-64": {
+      "version": "0.14.49",
+      "resolved": "https://registry.npmjs.org/esbuild-linux-64/-/esbuild-linux-64-0.14.49.tgz",
+      "integrity": "sha512-hYmzRIDzFfLrB5c1SknkxzM8LdEUOusp6M2TnuQZJLRtxTgyPnZZVtyMeCLki0wKgYPXkFsAVhi8vzo2mBNeTg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/esbuild/node_modules/esbuild-linux-arm": {
+      "version": "0.14.49",
+      "resolved": "https://registry.npmjs.org/esbuild-linux-arm/-/esbuild-linux-arm-0.14.49.tgz",
+      "integrity": "sha512-iE3e+ZVv1Qz1Sy0gifIsarJMQ89Rpm9mtLSRtG3AH0FPgAzQ5Z5oU6vYzhc/3gSPi2UxdCOfRhw2onXuFw/0lg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/esbuild/node_modules/esbuild-linux-arm64": {
+      "version": "0.14.49",
+      "resolved": "https://registry.npmjs.org/esbuild-linux-arm64/-/esbuild-linux-arm64-0.14.49.tgz",
+      "integrity": "sha512-KLQ+WpeuY+7bxukxLz5VgkAAVQxUv67Ft4DmHIPIW+2w3ObBPQhqNoeQUHxopoW/aiOn3m99NSmSV+bs4BSsdA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/esbuild/node_modules/esbuild-linux-mips64le": {
+      "version": "0.14.49",
+      "resolved": "https://registry.npmjs.org/esbuild-linux-mips64le/-/esbuild-linux-mips64le-0.14.49.tgz",
+      "integrity": "sha512-n+rGODfm8RSum5pFIqFQVQpYBw+AztL8s6o9kfx7tjfK0yIGF6tm5HlG6aRjodiiKkH2xAiIM+U4xtQVZYU4rA==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/esbuild/node_modules/esbuild-linux-ppc64le": {
+      "version": "0.14.49",
+      "resolved": "https://registry.npmjs.org/esbuild-linux-ppc64le/-/esbuild-linux-ppc64le-0.14.49.tgz",
+      "integrity": "sha512-WP9zR4HX6iCBmMFH+XHHng2LmdoIeUmBpL4aL2TR8ruzXyT4dWrJ5BSbT8iNo6THN8lod6GOmYDLq/dgZLalGw==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/esbuild/node_modules/esbuild-linux-riscv64": {
+      "version": "0.14.49",
+      "resolved": "https://registry.npmjs.org/esbuild-linux-riscv64/-/esbuild-linux-riscv64-0.14.49.tgz",
+      "integrity": "sha512-h66ORBz+Dg+1KgLvzTVQEA1LX4XBd1SK0Fgbhhw4akpG/YkN8pS6OzYI/7SGENiN6ao5hETRDSkVcvU9NRtkMQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/esbuild/node_modules/esbuild-linux-s390x": {
+      "version": "0.14.49",
+      "resolved": "https://registry.npmjs.org/esbuild-linux-s390x/-/esbuild-linux-s390x-0.14.49.tgz",
+      "integrity": "sha512-DhrUoFVWD+XmKO1y7e4kNCqQHPs6twz6VV6Uezl/XHYGzM60rBewBF5jlZjG0nCk5W/Xy6y1xWeopkrhFFM0sQ==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/esbuild/node_modules/esbuild-netbsd-64": {
+      "version": "0.14.49",
+      "resolved": "https://registry.npmjs.org/esbuild-netbsd-64/-/esbuild-netbsd-64-0.14.49.tgz",
+      "integrity": "sha512-BXaUwFOfCy2T+hABtiPUIpWjAeWK9P8O41gR4Pg73hpzoygVGnj0nI3YK4SJhe52ELgtdgWP/ckIkbn2XaTxjQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/esbuild/node_modules/esbuild-openbsd-64": {
+      "version": "0.14.49",
+      "resolved": "https://registry.npmjs.org/esbuild-openbsd-64/-/esbuild-openbsd-64-0.14.49.tgz",
+      "integrity": "sha512-lP06UQeLDGmVPw9Rg437Btu6J9/BmyhdoefnQ4gDEJTtJvKtQaUcOQrhjTq455ouZN4EHFH1h28WOJVANK41kA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/esbuild/node_modules/esbuild-sunos-64": {
+      "version": "0.14.49",
+      "resolved": "https://registry.npmjs.org/esbuild-sunos-64/-/esbuild-sunos-64-0.14.49.tgz",
+      "integrity": "sha512-4c8Zowp+V3zIWje329BeLbGh6XI9c/rqARNaj5yPHdC61pHI9UNdDxT3rePPJeWcEZVKjkiAS6AP6kiITp7FSw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/esbuild/node_modules/esbuild-windows-32": {
+      "version": "0.14.49",
+      "resolved": "https://registry.npmjs.org/esbuild-windows-32/-/esbuild-windows-32-0.14.49.tgz",
+      "integrity": "sha512-q7Rb+J9yHTeKr9QTPDYkqfkEj8/kcKz9lOabDuvEXpXuIcosWCJgo5Z7h/L4r7rbtTH4a8U2FGKb6s1eeOHmJA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/esbuild/node_modules/esbuild-windows-64": {
+      "version": "0.14.49",
+      "resolved": "https://registry.npmjs.org/esbuild-windows-64/-/esbuild-windows-64-0.14.49.tgz",
+      "integrity": "sha512-+Cme7Ongv0UIUTniPqfTX6mJ8Deo7VXw9xN0yJEN1lQMHDppTNmKwAM3oGbD/Vqff+07K2gN0WfNkMohmG+dVw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/esbuild/node_modules/esbuild-windows-arm64": {
+      "version": "0.14.49",
+      "resolved": "https://registry.npmjs.org/esbuild-windows-arm64/-/esbuild-windows-arm64-0.14.49.tgz",
+      "integrity": "sha512-v+HYNAXzuANrCbbLFJ5nmO3m5y2PGZWLe3uloAkLt87aXiO2mZr3BTmacZdjwNkNEHuH3bNtN8cak+mzVjVPfA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
     },
     "node_modules/escalade": {
       "version": "3.1.1",
@@ -25878,92 +26105,151 @@
         "esbuild-windows-32": "0.14.49",
         "esbuild-windows-64": "0.14.49",
         "esbuild-windows-arm64": "0.14.49"
+      },
+      "dependencies": {
+        "esbuild-android-64": {
+          "version": "0.14.49",
+          "resolved": "https://registry.npmjs.org/esbuild-android-64/-/esbuild-android-64-0.14.49.tgz",
+          "integrity": "sha512-vYsdOTD+yi+kquhBiFWl3tyxnj2qZJsl4tAqwhT90ktUdnyTizgle7TjNx6Ar1bN7wcwWqZ9QInfdk2WVagSww==",
+          "dev": true,
+          "optional": true
+        },
+        "esbuild-android-arm64": {
+          "version": "0.14.49",
+          "resolved": "https://registry.npmjs.org/esbuild-android-arm64/-/esbuild-android-arm64-0.14.49.tgz",
+          "integrity": "sha512-g2HGr/hjOXCgSsvQZ1nK4nW/ei8JUx04Li74qub9qWrStlysaVmadRyTVuW32FGIpLQyc5sUjjZopj49eGGM2g==",
+          "dev": true,
+          "optional": true
+        },
+        "esbuild-darwin-arm64": {
+          "version": "0.14.49",
+          "resolved": "https://registry.npmjs.org/esbuild-darwin-arm64/-/esbuild-darwin-arm64-0.14.49.tgz",
+          "integrity": "sha512-XMaqDxO846srnGlUSJnwbijV29MTKUATmOLyQSfswbK/2X5Uv28M9tTLUJcKKxzoo9lnkYPsx2o8EJcTYwCs/A==",
+          "dev": true,
+          "optional": true
+        },
+        "esbuild-freebsd-64": {
+          "version": "0.14.49",
+          "resolved": "https://registry.npmjs.org/esbuild-freebsd-64/-/esbuild-freebsd-64-0.14.49.tgz",
+          "integrity": "sha512-NJ5Q6AjV879mOHFri+5lZLTp5XsO2hQ+KSJYLbfY9DgCu8s6/Zl2prWXVANYTeCDLlrIlNNYw8y34xqyLDKOmQ==",
+          "dev": true,
+          "optional": true
+        },
+        "esbuild-freebsd-arm64": {
+          "version": "0.14.49",
+          "resolved": "https://registry.npmjs.org/esbuild-freebsd-arm64/-/esbuild-freebsd-arm64-0.14.49.tgz",
+          "integrity": "sha512-lFLtgXnAc3eXYqj5koPlBZvEbBSOSUbWO3gyY/0+4lBdRqELyz4bAuamHvmvHW5swJYL7kngzIZw6kdu25KGOA==",
+          "dev": true,
+          "optional": true
+        },
+        "esbuild-linux-32": {
+          "version": "0.14.49",
+          "resolved": "https://registry.npmjs.org/esbuild-linux-32/-/esbuild-linux-32-0.14.49.tgz",
+          "integrity": "sha512-zTTH4gr2Kb8u4QcOpTDVn7Z8q7QEIvFl/+vHrI3cF6XOJS7iEI1FWslTo3uofB2+mn6sIJEQD9PrNZKoAAMDiA==",
+          "dev": true,
+          "optional": true
+        },
+        "esbuild-linux-64": {
+          "version": "0.14.49",
+          "resolved": "https://registry.npmjs.org/esbuild-linux-64/-/esbuild-linux-64-0.14.49.tgz",
+          "integrity": "sha512-hYmzRIDzFfLrB5c1SknkxzM8LdEUOusp6M2TnuQZJLRtxTgyPnZZVtyMeCLki0wKgYPXkFsAVhi8vzo2mBNeTg==",
+          "dev": true,
+          "optional": true
+        },
+        "esbuild-linux-arm": {
+          "version": "0.14.49",
+          "resolved": "https://registry.npmjs.org/esbuild-linux-arm/-/esbuild-linux-arm-0.14.49.tgz",
+          "integrity": "sha512-iE3e+ZVv1Qz1Sy0gifIsarJMQ89Rpm9mtLSRtG3AH0FPgAzQ5Z5oU6vYzhc/3gSPi2UxdCOfRhw2onXuFw/0lg==",
+          "dev": true,
+          "optional": true
+        },
+        "esbuild-linux-arm64": {
+          "version": "0.14.49",
+          "resolved": "https://registry.npmjs.org/esbuild-linux-arm64/-/esbuild-linux-arm64-0.14.49.tgz",
+          "integrity": "sha512-KLQ+WpeuY+7bxukxLz5VgkAAVQxUv67Ft4DmHIPIW+2w3ObBPQhqNoeQUHxopoW/aiOn3m99NSmSV+bs4BSsdA==",
+          "dev": true,
+          "optional": true
+        },
+        "esbuild-linux-mips64le": {
+          "version": "0.14.49",
+          "resolved": "https://registry.npmjs.org/esbuild-linux-mips64le/-/esbuild-linux-mips64le-0.14.49.tgz",
+          "integrity": "sha512-n+rGODfm8RSum5pFIqFQVQpYBw+AztL8s6o9kfx7tjfK0yIGF6tm5HlG6aRjodiiKkH2xAiIM+U4xtQVZYU4rA==",
+          "dev": true,
+          "optional": true
+        },
+        "esbuild-linux-ppc64le": {
+          "version": "0.14.49",
+          "resolved": "https://registry.npmjs.org/esbuild-linux-ppc64le/-/esbuild-linux-ppc64le-0.14.49.tgz",
+          "integrity": "sha512-WP9zR4HX6iCBmMFH+XHHng2LmdoIeUmBpL4aL2TR8ruzXyT4dWrJ5BSbT8iNo6THN8lod6GOmYDLq/dgZLalGw==",
+          "dev": true,
+          "optional": true
+        },
+        "esbuild-linux-riscv64": {
+          "version": "0.14.49",
+          "resolved": "https://registry.npmjs.org/esbuild-linux-riscv64/-/esbuild-linux-riscv64-0.14.49.tgz",
+          "integrity": "sha512-h66ORBz+Dg+1KgLvzTVQEA1LX4XBd1SK0Fgbhhw4akpG/YkN8pS6OzYI/7SGENiN6ao5hETRDSkVcvU9NRtkMQ==",
+          "dev": true,
+          "optional": true
+        },
+        "esbuild-linux-s390x": {
+          "version": "0.14.49",
+          "resolved": "https://registry.npmjs.org/esbuild-linux-s390x/-/esbuild-linux-s390x-0.14.49.tgz",
+          "integrity": "sha512-DhrUoFVWD+XmKO1y7e4kNCqQHPs6twz6VV6Uezl/XHYGzM60rBewBF5jlZjG0nCk5W/Xy6y1xWeopkrhFFM0sQ==",
+          "dev": true,
+          "optional": true
+        },
+        "esbuild-netbsd-64": {
+          "version": "0.14.49",
+          "resolved": "https://registry.npmjs.org/esbuild-netbsd-64/-/esbuild-netbsd-64-0.14.49.tgz",
+          "integrity": "sha512-BXaUwFOfCy2T+hABtiPUIpWjAeWK9P8O41gR4Pg73hpzoygVGnj0nI3YK4SJhe52ELgtdgWP/ckIkbn2XaTxjQ==",
+          "dev": true,
+          "optional": true
+        },
+        "esbuild-openbsd-64": {
+          "version": "0.14.49",
+          "resolved": "https://registry.npmjs.org/esbuild-openbsd-64/-/esbuild-openbsd-64-0.14.49.tgz",
+          "integrity": "sha512-lP06UQeLDGmVPw9Rg437Btu6J9/BmyhdoefnQ4gDEJTtJvKtQaUcOQrhjTq455ouZN4EHFH1h28WOJVANK41kA==",
+          "dev": true,
+          "optional": true
+        },
+        "esbuild-sunos-64": {
+          "version": "0.14.49",
+          "resolved": "https://registry.npmjs.org/esbuild-sunos-64/-/esbuild-sunos-64-0.14.49.tgz",
+          "integrity": "sha512-4c8Zowp+V3zIWje329BeLbGh6XI9c/rqARNaj5yPHdC61pHI9UNdDxT3rePPJeWcEZVKjkiAS6AP6kiITp7FSw==",
+          "dev": true,
+          "optional": true
+        },
+        "esbuild-windows-32": {
+          "version": "0.14.49",
+          "resolved": "https://registry.npmjs.org/esbuild-windows-32/-/esbuild-windows-32-0.14.49.tgz",
+          "integrity": "sha512-q7Rb+J9yHTeKr9QTPDYkqfkEj8/kcKz9lOabDuvEXpXuIcosWCJgo5Z7h/L4r7rbtTH4a8U2FGKb6s1eeOHmJA==",
+          "dev": true,
+          "optional": true
+        },
+        "esbuild-windows-64": {
+          "version": "0.14.49",
+          "resolved": "https://registry.npmjs.org/esbuild-windows-64/-/esbuild-windows-64-0.14.49.tgz",
+          "integrity": "sha512-+Cme7Ongv0UIUTniPqfTX6mJ8Deo7VXw9xN0yJEN1lQMHDppTNmKwAM3oGbD/Vqff+07K2gN0WfNkMohmG+dVw==",
+          "dev": true,
+          "optional": true
+        },
+        "esbuild-windows-arm64": {
+          "version": "0.14.49",
+          "resolved": "https://registry.npmjs.org/esbuild-windows-arm64/-/esbuild-windows-arm64-0.14.49.tgz",
+          "integrity": "sha512-v+HYNAXzuANrCbbLFJ5nmO3m5y2PGZWLe3uloAkLt87aXiO2mZr3BTmacZdjwNkNEHuH3bNtN8cak+mzVjVPfA==",
+          "dev": true,
+          "optional": true
+        }
       }
-    },
-    "esbuild-android-64": {
-      "dev": true,
-      "optional": true
-    },
-    "esbuild-android-arm64": {
-      "dev": true,
-      "optional": true
     },
     "esbuild-darwin-64": {
       "version": "0.14.49",
       "dev": true,
       "optional": true
     },
-    "esbuild-darwin-arm64": {
-      "dev": true,
-      "optional": true
-    },
-    "esbuild-freebsd-64": {
-      "dev": true,
-      "optional": true
-    },
-    "esbuild-freebsd-arm64": {
-      "dev": true,
-      "optional": true
-    },
-    "esbuild-linux-32": {
-      "dev": true,
-      "optional": true
-    },
-    "esbuild-linux-64": {
-      "dev": true,
-      "optional": true
-    },
-    "esbuild-linux-arm": {
-      "dev": true,
-      "optional": true
-    },
-    "esbuild-linux-arm64": {
-      "dev": true,
-      "optional": true
-    },
-    "esbuild-linux-mips64le": {
-      "dev": true,
-      "optional": true
-    },
-    "esbuild-linux-ppc64le": {
-      "dev": true,
-      "optional": true
-    },
-    "esbuild-linux-riscv64": {
-      "dev": true,
-      "optional": true
-    },
-    "esbuild-linux-s390x": {
-      "dev": true,
-      "optional": true
-    },
-    "esbuild-netbsd-64": {
-      "dev": true,
-      "optional": true
-    },
-    "esbuild-openbsd-64": {
-      "dev": true,
-      "optional": true
-    },
-    "esbuild-sunos-64": {
-      "dev": true,
-      "optional": true
-    },
     "esbuild-wasm": {
       "version": "0.14.49",
       "dev": true
-    },
-    "esbuild-windows-32": {
-      "dev": true,
-      "optional": true
-    },
-    "esbuild-windows-64": {
-      "dev": true,
-      "optional": true
-    },
-    "esbuild-windows-arm64": {
-      "dev": true,
-      "optional": true
     },
     "escalade": {
       "version": "3.1.1",

--- a/package.json
+++ b/package.json
@@ -45,7 +45,6 @@
     "@angular/platform-browser": "~14.1.2",
     "@angular/platform-browser-dynamic": "~14.1.2",
     "@angular/router": "^14.1.2",
-    "debug": "^4.1.1",
     "direction": "^1.0.3",
     "is-hotkey": "^0.1.6",
     "rxjs": "~6.6.0",

--- a/packages/src/components/editable/editable.component.ts
+++ b/packages/src/components/editable/editable.component.ts
@@ -38,7 +38,6 @@ import Hotkeys from '../../utils/hotkeys';
 import { BeforeInputEvent, extractBeforeInputEvent } from '../../custom-event/BeforeInputEventPlugin';
 import { BEFORE_INPUT_EVENTS } from '../../custom-event/before-input-polyfill';
 import { SlateErrorCode } from '../../types/error';
-import Debug from 'debug';
 import { SlateStringTemplateComponent } from '../string/template.component';
 import { NG_VALUE_ACCESSOR } from '@angular/forms';
 import { SlateChildrenContext, SlateViewContext } from '../../view/context';
@@ -47,8 +46,6 @@ import { HistoryEditor } from 'slate-history';
 import { isDecoratorRangeListEqual } from '../../utils';
 import { check, normalize } from '../../utils/global-normalize';
 import { SlatePlaceholder } from '../../types/feature';
-
-const timeDebug = Debug('slate-angular-time');
 
 // not correctly clipboardData on beforeinput
 const forceOnDOMPaste = IS_SAFARI;
@@ -291,7 +288,7 @@ export class SlateEditableComponent implements OnInit, OnChanges, OnDestroy, Aft
             ) {
                 return;
             }
-            
+
             // prevent updating native selection when active element is void element
             if (isTargetInsideVoid(this.editor, activeElement)) {
                 return;
@@ -356,15 +353,12 @@ export class SlateEditableComponent implements OnInit, OnChanges, OnDestroy, Aft
     }
 
     ngAfterViewChecked() {
-        timeDebug('editable ngAfterViewChecked');
     }
 
     ngDoCheck() {
-        timeDebug('editable ngDoCheck');
     }
 
     forceFlush() {
-        timeDebug('start data sync');
         this.detectContext();
         this.cdr.detectChanges();
         // repair collaborative editing when Chinese input is interrupted by other users' cursors
@@ -401,7 +395,6 @@ export class SlateEditableComponent implements OnInit, OnChanges, OnDestroy, Aft
             }, 0);
         }
         this.toNativeSelection();
-        timeDebug('end data sync');
     }
 
     initializeContext() {


### PR DESCRIPTION
Remove debug package from *production* dependencies to reduce attack vectors and bundle size. 