### PR TITLE
fix(core): fix legacy check for edge and firefox v100+

### DIFF
--- a/.changeset/cool-snails-refuse.md
+++ b/.changeset/cool-snails-refuse.md
@@ -1,0 +1,5 @@
+---
+"slate-angular": patch
+---
+
+fix legacy check for Edge and Firefox v100+

--- a/packages/src/utils/environment.ts
+++ b/packages/src/utils/environment.ts
@@ -21,7 +21,7 @@ export const IS_SAFARI =
 // "modern" Edge was released at 79.x
 export const IS_EDGE_LEGACY =
     typeof navigator !== 'undefined' &&
-    /Edge?\/(?:[0-6][0-9]|[0-7][0-8])/i.test(navigator.userAgent);
+    /Edge?\/(?:[0-6][0-9]|[0-7][0-8])(?:\.)/i.test(navigator.userAgent);
 
 export const IS_CHROME =
     typeof navigator !== 'undefined' && /Chrome/i.test(navigator.userAgent);
@@ -37,7 +37,7 @@ export const IS_CHROME_LEGACY =
 // Firefox did not support `beforeInput` until `v87`.
 export const IS_FIREFOX_LEGACY =
     typeof navigator !== 'undefined' &&
-    /^(?!.*Seamonkey)(?=.*Firefox\/(?:[0-7][0-9]|[0-8][0-6])).*/i.test(
+    /^(?!.*Seamonkey)(?=.*Firefox\/(?:[0-7][0-9]|[0-8][0-6])(?:\.)).*/i.test(
         navigator.userAgent
     );
 


### PR DESCRIPTION
Due to the legacy Edge check failed in Edge v100+, the onDOMBeforeInput method has not been bound to the editor dom element. So there would be the issue in #219 